### PR TITLE
fix: prevent menu open for email address

### DIFF
--- a/src/app/feature/comments/comment-input/comment-input.component.html
+++ b/src/app/feature/comments/comment-input/comment-input.component.html
@@ -7,7 +7,7 @@
   class="block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300"
   (keydown.ArrowDown)="arrowUpDown($event)"
   (keydown.ArrowUp)="arrowUpDown($event)"
-  (keydown.Tab)="onTabDown()"
+  (keydown.Tab)="onTabDown($event)"
   (keyup)="onKeyUp($event)"
   placeholder="Type a comment... @ to mention someone"
 ></textarea>

--- a/src/app/feature/comments/comment-input/comment-input.component.ts
+++ b/src/app/feature/comments/comment-input/comment-input.component.ts
@@ -45,12 +45,20 @@ export class CommentInputComponent {
 
     if (this.showMenu && (keyupEvent.key === 'Enter' || keyupEvent.key === 'Tab')) {
       this.selectUser(this.filteredUsers[this.selectedIndex]);
-      this.closeMenu();
       return;
     }
 
     if (lastAtIndex !== -1) {
       const mentionQuery = textBeforeCursor.substring(lastAtIndex + 1);
+
+      // Check if the character before '@' is a space, empty (start of line), or newline
+      const charBeforeAt = textBeforeCursor.charAt(lastAtIndex - 1);
+      if (charBeforeAt !== ' ' && charBeforeAt !== '' && charBeforeAt !== '\n') {
+        this.closeMenu();
+        return;
+      }
+
+
       this.filteredUsers = this.users().filter((user) => user.name.toLowerCase().includes(mentionQuery.toLowerCase()));
 
       if (this.filteredUsers.length > 0) {
@@ -78,10 +86,10 @@ export class CommentInputComponent {
     }
   }
 
-  onTabDown(): void {
+  onTabDown(tabKeyupEvent: Event): void {
     if (this.showMenu) {
+      tabKeyupEvent.preventDefault();
       this.selectUser(this.filteredUsers[this.selectedIndex]);
-      this.closeMenu();
     }
   }
 
@@ -100,6 +108,7 @@ export class CommentInputComponent {
       textBeforeCursor.substring(0, lastAtIndex + 1) + user.name + ' ' + textarea.value.substring(cursorPosition);
 
     this.closeMenu();
+    textarea.focus(); // bring focus after menu closes
   }
 
   onConfirmButtonPress(): void {


### PR DESCRIPTION
- prevent mention menu from opening when character before '@' is space, empty, or newline
- keep focus on textarea element after tab key press.

**Screenshots:**

_GIF showing the working solution._
![chrome_Yzr0uVVC4q](https://github.com/user-attachments/assets/0ea0a0a0-f6e6-40bc-a024-481accdc02fe)
